### PR TITLE
Release for v0.0.1

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,4 @@
+changelog:
+  exclude:
+    labels:
+      - tagpr

--- a/.tagpr
+++ b/.tagpr
@@ -1,0 +1,28 @@
+# config file for the tagpr in git config format
+# The tagpr generates the initial configuration, which you can rewrite to suit your environment.
+# CONFIGURATIONS:
+#   tagpr.releaseBranch
+#       Generally, it is "main." It is the branch for releases. The pcpr tracks this branch,
+#       creates or updates a pull request as a release candidate, or tags when they are merged.
+#
+#   tagpr.versinFile
+#       Versioning file containing the semantic version needed to be updated at release.
+#       It will be synchronized with the "git tag".
+#       Often this is a meta-information file such as gemspec, setup.cfg, package.json, etc.
+#       Sometimes the source code file, such as version.go or Bar.pm, is used.
+#       If you do not want to use versioning files but only git tags, specify the "-" string here.
+#       You can specify multiple version files by comma separated strings.
+#
+#   tagpr.vPrefix
+#       Flag whether or not v-prefix is added to semver when git tagging. (e.g. v1.2.3 if true)
+#       This is only a tagging convention, not how it is described in the version file.
+#
+#   tagpr.command (Optional)
+#       Command to change files just before release.
+#
+#   tagpr.tmplate (Optional)
+#       Pull request template in go template format
+[tagpr]
+	vPrefix = true
+	releaseBranch = main
+	versionFile = version.go

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## [v0.0.1](https://github.com/Songmu/gh2changelog/commits/v0.0.1) - 2022-08-31
+- output unreleased by @Songmu in https://github.com/Songmu/gh2changelog/pull/1
+- make some methods public by @Songmu in https://github.com/Songmu/gh2changelog/pull/3
+- implement cli tool 'gh2changelog' by @Songmu in https://github.com/Songmu/gh2changelog/pull/4
+- update README.md by @Songmu in https://github.com/Songmu/gh2changelog/pull/5

--- a/version.go
+++ b/version.go
@@ -1,5 +1,5 @@
 package gh2changelog
 
-const version = "0.0.0"
+const version = "0.0.1"
 
 var revision = "HEAD"


### PR DESCRIPTION
This pull request is for the next release as v0.0.1 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.0.1 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.0.0" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
## What's Changed
* output unreleased by @Songmu in https://github.com/Songmu/gh2changelog/pull/1
* make some methods public by @Songmu in https://github.com/Songmu/gh2changelog/pull/3
* implement cli tool 'gh2changelog' by @Songmu in https://github.com/Songmu/gh2changelog/pull/4
* update README.md by @Songmu in https://github.com/Songmu/gh2changelog/pull/5

## New Contributors
* @Songmu made their first contribution in https://github.com/Songmu/gh2changelog/pull/1

**Full Changelog**: https://github.com/Songmu/gh2changelog/commits/v0.0.1