### PR TITLE
Release for v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [v0.2.0](https://github.com/Songmu/gh2changelog/compare/v0.1.0...v0.2.0) - 2025-09-07
+- update deps and github actions by @Songmu in https://github.com/Songmu/gh2changelog/pull/20
+
 ## [v0.1.0](https://github.com/Songmu/gh2changelog/compare/v0.0.5...v0.1.0) - 2024-10-22
 - update deps and Go version by @Songmu in https://github.com/Songmu/gh2changelog/pull/18
 

--- a/version.go
+++ b/version.go
@@ -1,5 +1,5 @@
 package gh2changelog
 
-const version = "0.1.0"
+const version = "0.2.0"
 
 var revision = "HEAD"


### PR DESCRIPTION
This pull request is for the next release as v0.2.0 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.2.0 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.1.0" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* update deps and github actions by @Songmu in https://github.com/Songmu/gh2changelog/pull/20


**Full Changelog**: https://github.com/Songmu/gh2changelog/compare/v0.1.0...v0.2.0