### PR TITLE
feat: add TagPrefix support for monorepo

### DIFF
--- a/gh2changelog.go
+++ b/gh2changelog.go
@@ -23,8 +23,9 @@ type releaseNoteGenerator interface {
 
 // GH2Changelog is to output changelogs
 type GH2Changelog struct {
-	gitPath  string
-	repoPath string
+	gitPath   string
+	repoPath  string
+	tagPrefix string
 
 	owner, repo, remoteName string
 	outStream, errStream    io.Writer
@@ -57,7 +58,11 @@ func New(ctx context.Context, opts ...Option) (*GH2Changelog, error) {
 			errStream: gch.errStream}
 	}
 	if gch.semvers == nil {
-		gch.semvers = (&gitsemvers.Semvers{GitPath: gch.gitPath, RepoPath: gch.repoPath}).VersionStrings()
+		gch.semvers = (&gitsemvers.Semvers{
+			GitPath:   gch.gitPath,
+			RepoPath:  gch.repoPath,
+			TagPrefix: gch.tagPrefix,
+		}).VersionStrings()
 	}
 
 	var err error

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.25.0
 
 require (
 	github.com/Songmu/gitconfig v0.2.1
-	github.com/Songmu/gitsemvers v0.0.3
+	github.com/Songmu/gitsemvers v0.1.0
 	github.com/google/go-github/v74 v74.0.0
 	golang.org/x/oauth2 v0.33.0
 )
@@ -16,9 +16,7 @@ require (
 	github.com/cli/safeexec v1.0.1 // indirect
 	github.com/goccy/go-yaml v1.18.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
-	github.com/jessevdk/go-flags v1.6.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
-	golang.org/x/mod v0.27.0 // indirect
-	golang.org/x/sys v0.36.0 // indirect
+	golang.org/x/mod v0.31.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/Songmu/gitconfig v0.2.1 h1:cZsqELfMtxWVI8ovq17gbvsR4qLfoYLAiXy5GwtJWb
 github.com/Songmu/gitconfig v0.2.1/go.mod h1:XM4O3SoXFnli9Ql2G7qXK2Fg7LJwf7Hs8GLFEOJlzmM=
 github.com/Songmu/gitmock v0.0.2 h1:KF5GTll60LxGskZbt58QDd29y/GYLgdxqvkvnSU6RlY=
 github.com/Songmu/gitmock v0.0.2/go.mod h1:/ILc8CtPydh2MJ8toKCOB1opd2HCaU/6RWJjg7lmSvs=
-github.com/Songmu/gitsemvers v0.0.3 h1:pyNgp4+G0Y65zP+4ANybm/fFUyThaMl3SrUzmh50ogk=
-github.com/Songmu/gitsemvers v0.0.3/go.mod h1:WdKXiC8zjNK1N7CoZ9cM9vrw/Bg6/W4AwGrfTkkUPdM=
+github.com/Songmu/gitsemvers v0.1.0 h1:7YX68SBAAU79VZqktyweU7GwNNvyH1zgUPop3YuHna8=
+github.com/Songmu/gitsemvers v0.1.0/go.mod h1:x91ks2iTqdK1teCZxqn+bAWSVezVDliOB3ehGGyJfqQ=
 github.com/cli/go-gh/v2 v2.12.2 h1:EtocmDAH7dKrH2PscQOQVo7PbFD5G6uYx4rSKY2w1SY=
 github.com/cli/go-gh/v2 v2.12.2/go.mod h1:g2IjwHEo27fgItlS9wUbRaXPYurZEXPp1jrxf3piC6g=
 github.com/cli/safeexec v1.0.1 h1:e/C79PbXF4yYTN/wauC4tviMxEV13BwljGj0N9j+N00=
@@ -20,8 +20,6 @@ github.com/google/go-github/v74 v74.0.0 h1:yZcddTUn8DPbj11GxnMrNiAnXH14gNs559AsU
 github.com/google/go-github/v74 v74.0.0/go.mod h1:ubn/YdyftV80VPSI26nSJvaEsTOnsjrxG3o9kJhcyak=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
-github.com/jessevdk/go-flags v1.6.1 h1:Cvu5U8UGrLay1rZfv/zP7iLpSHGUZ/Ou68T0iX1bBK4=
-github.com/jessevdk/go-flags v1.6.1/go.mod h1:Mk8T1hIAWpOiJiHa9rJASDK2UGWji0EuPGBnNLMooyc=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
@@ -30,12 +28,10 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-golang.org/x/mod v0.27.0 h1:kb+q2PyFnEADO2IEF935ehFUXlWiNjJWtRNgBLSfbxQ=
-golang.org/x/mod v0.27.0/go.mod h1:rWI627Fq0DEoudcK+MBkNkCe0EetEaDSwJJkCcjpazc=
+golang.org/x/mod v0.31.0 h1:HaW9xtz0+kOcWKwli0ZXy79Ix+UW/vOfmWI5QVd2tgI=
+golang.org/x/mod v0.31.0/go.mod h1:43JraMp9cGx1Rx3AqioxrbrhNsLl2l/iNAvuBkrezpg=
 golang.org/x/oauth2 v0.33.0 h1:4Q+qn+E5z8gPRJfmRy7C2gGG3T4jIprK6aSYgTXGRpo=
 golang.org/x/oauth2 v0.33.0/go.mod h1:lzm5WQJQwKZ3nwavOZ3IS5Aulzxi68dUSgRHujetwEA=
-golang.org/x/sys v0.36.0 h1:KVRy2GtZBrk1cBYA7MKu5bEZFxQk4NIDV6RLVcC8o0k=
-golang.org/x/sys v0.36.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=

--- a/options.go
+++ b/options.go
@@ -34,3 +34,10 @@ func GitHubClient(cli *github.Client) Option {
 		gch.gen = cli.Repositories
 	}
 }
+
+// TagPrefix sets a tag prefix for monorepo support
+func TagPrefix(p string) Option {
+	return func(gch *GH2Changelog) {
+		gch.tagPrefix = p
+	}
+}


### PR DESCRIPTION
First of all, thank you for creating and maintaining this awesome project! 🙏

### Summary

Add `TagPrefix` option to filter tags by prefix.
This enables monorepo support with prefixed tags like `modules/vpc/v1.0.0`.

### Motivation

This change is a prerequisite for completing monorepo support in tagpr ([Songmu/tagpr#268](https://github.com/Songmu/tagpr/pull/268)).

In monorepos, tags often include path prefixes (e.g., `modules/vpc/v1.0.0`, `tools/v1.2.3`).
By adding prefix filtering to gh2changelog, tagpr can properly generate changelogs for each module.

### Usage

```go
gch, err := gh2changelog.New(ctx,
    gh2changelog.TagPrefix("modules/vpc"),
)
// Now correctly finds tags like "modules/vpc/v1.0.0"
```

### Changes

- Add `TagPrefix` option to filter tags by prefix
- Pass `TagPrefix` to gitsemvers internally
- Update gitsemvers to v0.1.0 for TagPrefix support